### PR TITLE
fix mistake in rsync docs 

### DIFF
--- a/rsync/DOCS.md
+++ b/rsync/DOCS.md
@@ -18,7 +18,7 @@ folders:
     destination: /home/user/config-target
   - source: /media/playlists
     destination: /home/user/cool-playlists
-    options: '-archive --recursive --compress'
+    options: '--archive --recursive --compress'
 remote_host: ''
 remote_folder: /home/user
 


### PR DESCRIPTION
While the issue https://github.com/Poeschl/Hassio-Addons/issuee/380 had been fixed, the same issue remained in the docs.